### PR TITLE
Add instance-of helper

### DIFF
--- a/addon/-private/validators.js
+++ b/addon/-private/validators.js
@@ -17,13 +17,33 @@ export function createTypeValidator(expectedType) {
 
 /**
  * Validator to handle strict equality checking
- * @param {string} expectedValue - The value the validator expects
+ * @param {any} expectedValue - The value the validator expects
  * @returns {function} Validator function
  */
 export function createEqualityValidator(expectedValue) {
   return function(value) {
     if (value !== expectedValue) {
       return `Expected value to equal ${toString(expectedValue)} but received ${toString(value)}`;
+    }
+  }
+}
+
+/**
+ * Validator to handle instanceof checking
+ * @param {any} klass - The class the value should be an instance of
+ * @returns {function} Validator function
+ */
+export function createInstanceOfValidator(klass) {
+  /**
+   * @param {object} value - An object to structurally validate
+   * @param {function} context - The context for the path to any validation error
+   */
+  return function(value, context) {
+    if (!(value instanceof klass)) {
+      return [
+        `Expected value to be an instance of ${klass.name ?? toString(klass)} but received ${toString(value)}`,
+        context
+      ];
     }
   }
 }

--- a/addon/helpers/instance-of.js
+++ b/addon/helpers/instance-of.js
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+import { createInstanceOfValidator } from '../-private/validators';
+
+export function instanceOf([klass]) {
+  return createInstanceOfValidator(klass);
+}
+
+export default helper(instanceOf);

--- a/app/helpers/instance-of.js
+++ b/app/helpers/instance-of.js
@@ -1,0 +1,1 @@
+export { default, instanceOf } from 'ember-argument-types/helpers/instance-of';

--- a/tests/integration/helpers/arg-type-test.js
+++ b/tests/integration/helpers/arg-type-test.js
@@ -180,4 +180,16 @@ module('Integration | Helper | arg-type', function(hooks) {
       assert.ok(true, 'it didnt throw an error for null');
     });
   });
+
+  module('instance-of', function() {
+    test('it validates a value is an instance of a class', async function(assert) {
+      this.now = new Date();
+      this.Date = Date;
+
+      await render(hbs`
+        {{arg-type this.now (instance-of this.Date)}}
+      `);
+      assert.ok(true, 'it didnt throw an error');
+    });
+  });
 });

--- a/tests/unit/helpers/instance-of-test.js
+++ b/tests/unit/helpers/instance-of-test.js
@@ -1,0 +1,36 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { instanceOf } from 'dummy/helpers/instance-of';
+import { createContextPath } from '../../helpers/createContextPath';
+
+class MyClass {
+  foo = 'bar';
+}
+
+module('Unit | Helper | instance-of', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('it returns and error when the instance of check fails', function(assert) {
+    let [message] = instanceOf([MyClass])(undefined, createContextPath('myArg'));
+    assert.equal(
+      message,
+      'Expected value to be an instance of MyClass but received undefined',
+      'it returns the expected error message when provided a non array'
+    );
+
+    [message] = instanceOf([MyClass])('10/10/2020', createContextPath('myArg'));
+    assert.equal(
+      message,
+      'Expected value to be an instance of MyClass but received "10/10/2020"',
+      'it '
+    );
+  });
+
+  test('it returns undefined when the value is an instance of the class', function(assert) {
+    assert.equal(
+      instanceOf([MyClass])(new MyClass(), createContextPath('myArg')),
+      undefined,
+      'it returned undefined when provided an instance of the class',
+    );
+  });
+});


### PR DESCRIPTION
While its not exactly "clean" to perform these checks due to the requirement
to have access to the class in the template, providing this helper will allow
consuming apps to easily wrap the instance-of helper and provide their own
custom validators with minimal effort.