### PR TITLE
Avoid passing number to updateOrRetrieve in array-of helper

### DIFF
--- a/addon/-private/utils.js
+++ b/addon/-private/utils.js
@@ -20,6 +20,10 @@ const BASIC_VALIDATOR = {
  * a string argument to append to the path
  */
 export function createContextPath(path) {
+  /**
+   * @param {string} pathSegment - The path segment to append to the path
+   * @returns {function}
+   */
   return function updateOrRetrieve(pathSegment) {
     if (!pathSegment) {
       return path;

--- a/addon/-private/validators.js
+++ b/addon/-private/validators.js
@@ -1,6 +1,6 @@
 import { isArray } from '@ember/array';
 import { get } from '@ember/object';
-import { ensureValidator, toString, typeOf } from './utils';
+import { createContextPath, ensureValidator, toString, typeOf } from './utils';
 
 /**
  * Validator to handle type checking via typeof
@@ -89,7 +89,9 @@ export function createArrayValidator(validator) {
     }
 
     for (let i = 0; i < values.length; i++) {
-      const error = ensureValidator(validator)(values[i], context(i));
+      // Clone the current context to generate the correct context in the next iteration
+      const nextContext = createContextPath(context());
+      const error = ensureValidator(validator)(values[i], nextContext(`${i}`));
       if (error) {
         return error;
       }

--- a/tests/integration/helpers/arg-type-test.js
+++ b/tests/integration/helpers/arg-type-test.js
@@ -141,6 +141,33 @@ module('Integration | Helper | arg-type', function(hooks) {
       await render(hbs`{{arg-type this.value (array-of "string")}}`);
       assert.ok(true, 'it didnt throw an error');
     });
+    test('it validates arrays of objects with array-of', async function(assert) {
+      this.value = [
+        { name: 'user1' },
+        { name: 'user2' },
+        { name: 'user3' },
+      ];
+      await render(hbs`
+        {{arg-type
+          this.value
+          (array-of (shape-of name="string"))
+        }}
+      `);
+      assert.ok(true, 'it didnt throw an error');
+    });
+    test('it validates nested arrays with array-of', async function(assert) {
+      this.value = [
+        [1,2],
+        [3,4],
+      ];
+      await render(hbs`
+        {{arg-type
+          this.value
+          (array-of (array-of "number"))
+        }}
+      `);
+      assert.ok(true, 'it didnt throw an error');
+    });
   });
 
   module('one-of', function() {


### PR DESCRIPTION
The current `arrayOf`  helper passing updates the path with `context(i)` in each iteration. This causes a trouble when `i` is 0 because `updateOrRetrieve` will directly returns the string path instead of returning a updating function, and this breaks any usage when `arrayOf` is combined with other validators.

Fix this issue by stringnify the index and add test cases for array of objects and nested arrays.