### PR TITLE
Add an additional check to ensure the value is non-null in the shapeOf helper.

### DIFF
--- a/addon/-private/validators.js
+++ b/addon/-private/validators.js
@@ -64,8 +64,15 @@ export function createShapeValidator(validators) {
       return error;
     }
 
+    // Ensure the value is non-null so that we won't accidentally apply get to a null value
+    if (value === null) {
+      return [`Expected value to be a non-null object but received null`, context];
+    }
+
     for (const key of Object.keys(validators)) {
-      const error = ensureValidator(validators[key])(get(value, key), context(key));
+      // Clone the current context to generate the correct context in the next iteration
+      const nextContext = createContextPath(context());
+      const error = ensureValidator(validators[key])(get(value, key), nextContext(key));
       if (error) {
         return error;
       }

--- a/tests/unit/helpers/shape-of-test.js
+++ b/tests/unit/helpers/shape-of-test.js
@@ -21,6 +21,18 @@ module('Unit | Helper | shape-of', function(hooks) {
       'it does not update the context when provided a non object'
     );
 
+    [message, context] = validatorFn(null, createContextPath('myArg'));
+    assert.equal(
+      message,
+      'Expected value to be a non-null object but received null',
+      'it returns the expected error message when provided a non object'
+    );
+    assert.equal(
+      context(),
+      'myArg',
+      'it does not update the context when provided a non object'
+    );
+
     [message, context] = validatorFn({}, createContextPath('myArg'));
     assert.equal(
       message,
@@ -42,6 +54,31 @@ module('Unit | Helper | shape-of', function(hooks) {
     assert.equal(
       context(),
       'myArg.hello',
+      'it updates the context when an expected property is invalid'
+    );
+  });
+
+  test('it returns and error and updated context when a property fails for nested object', function(assert) {
+    const validatorFn = shapeOf([], {
+      parent: shapeOf([], {
+        success: 'number',
+        failure: 'boolean',
+      })
+    });
+    const [message, context] = validatorFn({
+      parent: {
+        success: 123,
+        failure: 'failed',
+      }
+    }, createContextPath('myArg'));
+    assert.equal(
+      message,
+      'Expected type boolean but received string',
+      'it returns the expected error message when an expected property is invalid'
+    );
+    assert.equal(
+      context(),
+      'myArg.parent.failure',
       'it updates the context when an expected property is invalid'
     );
   });


### PR DESCRIPTION
The existing shapeOf failed when the value is `null` since it passes `typeof value === 'object'` and breaks the app when it tries to use `get` from Ember.

Add an additional check to ensure the value is non-null in the shapeOf helper.